### PR TITLE
Table cells inherit font style from placeholder token

### DIFF
--- a/src/Processor/Exporter.php
+++ b/src/Processor/Exporter.php
@@ -217,6 +217,12 @@ class Exporter implements \Santwer\Exporter\Interfaces\ExporterInterface
 
 		if(!empty($this->tables)) {
 			foreach ($this->tables as $table => $tableData) {
+                if (!isset($tableData['defaultFontStyle'])) {
+                    $inherited = $templateProcessor->getTokenFontStyle($table);
+                    if (!empty($inherited)) {
+                        $tableData['defaultFontStyle'] = $inherited;
+                    }
+                }
 				$templateProcessor->setComplexBlock($table, $this->tableDataToComplexBlock($tableData));
 			}
 		}
@@ -254,6 +260,9 @@ class Exporter implements \Santwer\Exporter\Interfaces\ExporterInterface
 		$style = isset($tableData['style']) ? $tableData['style'] : null;
 		$table = new Table($style);
 
+        $defaultFontStyle      = $tableData['defaultFontStyle'] ?? null;
+        $defaultParagraphStyle = $tableData['defaultParagraphStyle'] ?? null;
+
 		if(isset($tableData['headers'])) {
 			$table->addRow();
 			foreach ($tableData['headers'] as $header) {
@@ -261,9 +270,17 @@ class Exporter implements \Santwer\Exporter\Interfaces\ExporterInterface
 					$table->addCell(
 						isset($header['width']) ? $header['width'] : null,
 						isset($header['style']) ? $header['style'] : null
-                    )->addText($this->templateProcessor->replace($header['text']));
+                    )->addText(
+                        $this->templateProcessor->replace($header['text']),
+                        $header['fontStyle'] ?? $defaultFontStyle,
+                        $header['paragraphStyle'] ?? $defaultParagraphStyle
+                    );
 				} else {
-                    $table->addCell()->addText($this->templateProcessor->replace($header));
+                    $table->addCell()->addText(
+                        $this->templateProcessor->replace($header),
+                        $defaultFontStyle,
+                        $defaultParagraphStyle
+                    );
 				}
 			}
 
@@ -277,9 +294,17 @@ class Exporter implements \Santwer\Exporter\Interfaces\ExporterInterface
 						$table->addCell(
 							isset($column['width']) ? $column['width'] : null,
 							isset($column['style']) ? $column['style'] : null
-                        )->addText($this->templateProcessor->replace($column['text']));
+                        )->addText(
+                            $this->templateProcessor->replace($column['text']),
+                            $column['fontStyle'] ?? $defaultFontStyle,
+                            $column['paragraphStyle'] ?? $defaultParagraphStyle
+                        );
 					} else {
-                        $table->addCell()->addText($this->templateProcessor->replace($column));
+                        $table->addCell()->addText(
+                            $this->templateProcessor->replace($column),
+                            $defaultFontStyle,
+                            $defaultParagraphStyle
+                        );
 					}
 				}
 			}


### PR DESCRIPTION
 Body:
  
  ## Summary

  - Adds `getTokenFontStyle()` to `TemplateProcessor` to extract the font style (name, size, bold, italic, color) from the Word XML run or paragraph containing a `${token}` placeholder
  - Before rendering each table, `Exporter` looks up the font style of the token it replaces and sets it as `defaultFontStyle` on the table data — unless an explicit `defaultFontStyle` is already provided
  - Propagates `defaultFontStyle` and `defaultParagraphStyle` to every header and body cell via `addText()`, with per-cell `fontStyle`/`paragraphStyle` overrides still taking precedence

  ## Motivation

  When a `${token}` in a Word template has a specific font style applied, tables that replace it would previously render in the document's default style, losing the formatting context set by the template author. This change
  makes table output visually consistent with the surrounding text.

  ## Behaviour

  | Scenario | Result |
  |---|---|
  | Token has font style, no override on cell | Cell inherits token's style |
  | Token has font style, cell has explicit `fontStyle` | Cell's own style wins |
  | `defaultFontStyle` already set on table data | Explicit value is kept, no lookup performed |
  | Token has no detectable style | No style applied (existing behaviour) |

  ## Test plan

  - [ ] Export a table via a template where the `${token}` has a custom font (name/size/bold/italic/color) and verify cells render with that style
  - [ ] Confirm per-cell `fontStyle` overrides still take effect
  - [ ] Confirm passing an explicit `defaultFontStyle` in table data skips the token lookup
  - [ ] Confirm tables with unstyled tokens export without regression
